### PR TITLE
psycopg2 update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ emoji
 requests
 sqlalchemy
 python-telegram-bot>=8.0.0
-psycopg2
+psycopg2-binary


### PR DESCRIPTION
Following heroku instructions, there is need to change the psycopg2 package to psycopg2-binary.